### PR TITLE
fix: eslint配置，8.0以后prettier 已经合并了prettiers/xxx 插件

### DIFF
--- a/packages/eslint-plugin-gm-react-app/index.js
+++ b/packages/eslint-plugin-gm-react-app/index.js
@@ -28,8 +28,8 @@ module.exports = {
         'plugin:import/errors',
         'plugin:promise/recommended',
         'prettier',
-        'prettier/react',
-        'prettier/standard',
+        // 'prettier/react',
+        // 'prettier/standard',
       ],
       plugins: ['gm-react-app', 'react-hooks', 'prettier', 'promise'],
       parserOptions: {
@@ -82,9 +82,9 @@ module.exports = {
             'plugin:import/typescript',
             'plugin:@typescript-eslint/recommended',
             'prettier',
-            'prettier/react',
-            'prettier/standard',
-            'prettier/@typescript-eslint',
+            // 'prettier/react',
+            // 'prettier/standard',
+            // 'prettier/@typescript-eslint',
           ],
           plugins: [
             'gm-react-app',


### PR DESCRIPTION
eslint 报错
```
Error: "prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
```

`eslint-plugin-gm-react-app/index.js`

eslint 删除 `prettier/react ` 等